### PR TITLE
Sc4s1-39 crear la view que permita activar un registro de coordinador

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 __pycache__
 db.sqlite3
+__pycache__/
 
 # Django #
 *.log

--- a/servicios/url.py
+++ b/servicios/url.py
@@ -1,6 +1,5 @@
 from django.urls import path
 from . import views
-from .views import nuevo_coordinador
 
 urlpatterns = [
     # Ruta de la página de inicio
@@ -16,4 +15,5 @@ urlpatterns = [
     path('clientes/activar/<int:id_cliente>', views.activar_cliente, name='activar_cliente'),
     path('clientes/desactivar/<int:id_cliente>', views.desactivar_cliente, name='desactivar_cliente'),
     path('coordinadores/nuevo', views.nuevo_coordinador, name='nuevo_coordinador'),
+    path('coordinadores/activar/<int:id_coordinador>', views.activar_coordinador, name='activar_coordinador'),
 ]

--- a/servicios/views.py
+++ b/servicios/views.py
@@ -184,3 +184,15 @@ def nuevo_coordinador(request):
         request,
         "coordinadores/nuevo.html"
     )
+
+def activar_coordinador(request, id_coordinador):
+    try:
+        coordinador = Coordinador.objects.get(id=id_coordinador)
+        if not (coordinador.activo):
+            coordinador.activo = True
+            coordinador.save()
+            return HttpResponse("El registro del coordinador ingresado fué activado")
+        else:
+            return HttpResponse("Registro de coordinador ya activado")
+    except ObjectDoesNotExist:
+        return HttpResponse("El id no coincide con ningun objeto")


### PR DESCRIPTION
- Crear una view para activar registros de Coordinadores

- Lo que se debe hacer es poner el field activo en True y guardarlo

- Una vez activado el registro solo mostrar un mensaje (más adelante redireccionaremos al listado)

- Agregar la url correspondiente (/coordinadores/activar/<int: id>)